### PR TITLE
list: Make find and findInRange return the index as a second return value

### DIFF
--- a/Functional.moon
+++ b/Functional.moon
@@ -100,11 +100,11 @@ list = setmetatable {
 
   findInRange: (tbl, first = 1, last = #tbl, predicate) ->
     for i = first, last, #tbl
-      return tbl[i] if predicate tbl[i], i, tbl
+      return tbl[i], i if predicate tbl[i], i, tbl
 
   find: (tbl, predicate) ->
     for i, v in ipairs tbl
-      return v if predicate v, i, tbl
+      return v, i if predicate v, i, tbl
 
   groupBy: (tbl, selector = _function.identity) ->
     groups = {}

--- a/Tests.moon
+++ b/Tests.moon
@@ -44,12 +44,14 @@ DependencyControl.UnitTestSuite "l0.Functional", (functional, deps) ->
         ut\assertEquals filtered, {"a", false}
 
       find: (ut, tbls) ->
-        result = functional.list.find tbls.numbersList, (v) -> v > 12
+        result, index = functional.list.find tbls.numbersList, (v) -> v > 12
         ut\assertEquals result, 13
+        ut\assertEquals index, 4
 
       findInRange: (ut, tbls) ->
-        result = functional.list.findInRange tbls.numbersList, 5, nil, (v) -> v > 12
+        result, index = functional.list.findInRange tbls.numbersList, 5, nil, (v) -> v > 12
         ut\assertEquals result, 14
+        ut\assertEquals index, 5
 
       indexBy: (ut, tbls) ->
         result = functional.list.indexBy tbls.tableList, "a"


### PR DESCRIPTION
Useful in cases where you need both the value and the index, e.g. in order to know where to insert a line into the subtitles object. Also makes the functions consistent with table.find. Should be backwards compatible with existing code.