### PR TITLE
string: Add max_parts argument to split

### DIFF
--- a/Functional.moon
+++ b/Functional.moon
@@ -388,13 +388,13 @@ _string = {
 
   escRegExp: (str) -> str\gsub "([\\/%^%$%.|%?%*%+%(%)%[%]%{%}])", "\\%1"
 
-  split: (str, sep = " ", init = 1, plain = true) ->
+  split: (str, sep = " ", init = 1, plain = true, limit = -1) ->
     first, last = str\find sep, init, plain
     -- fast return if there's nothing to split - saves one str.sub()
-    return {str} unless first
+    return {str}, 1 if not first or limit == 0
 
     splits, s = {}, 1
-    while first
+    while first and s != limit + 1
       splits[s] = str\sub init, first - 1
       s += 1
       init = last + 1

--- a/Tests.moon
+++ b/Tests.moon
@@ -177,4 +177,36 @@ DependencyControl.UnitTestSuite "l0.Functional", (functional, deps) ->
                "removeValues", "slice", "trimEnd", "trimBoth", "map", "mapCompact", "reduce", "pluck",
                "uniq", "uniqCallback", "listMetaType", "removeWhere"}
     }
+    StringFunctions: {
+      _description: "Test all functions for strings (string.*)"
+      _setup: (ut) ->
+        testData = {
+          string: "This is a test."
+          uniString: "仕方が無い"
+          splitString: "a,b,,cde,%w+f,"
+        }
+
+        return testData
+
+      split: (ut, strs) ->
+        a, an = functional.string.split strs.splitString, ","
+        b, bn = functional.string.split strs.splitString, ",,"
+        c, cn = functional.string.split strs.splitString, ",", 5
+        d, dn = functional.string.split strs.splitString, "%w+", 1, true
+        e, en = functional.string.split strs.splitString, "%w+", 1, false
+        f, fn = functional.string.split strs.splitString, ",", 1, true, 2
+        g, gn = functional.string.split strs.splitString, ",", 1, true, 20
+        h, hn = functional.string.split strs.splitString, "!"
+        ut\assertEquals a, {"a", "b", "", "cde", "%w+f", ""}
+        ut\assertEquals b, {"a,b", "cde,%w+f,"}
+        ut\assertEquals c, {"", "cde", "%w+f", ""}
+        ut\assertEquals d, {"a,b,,cde,", "f,"}
+        ut\assertEquals e, {"", ",", ",,", ",%", "+", ","}
+        ut\assertEquals f, {"a", "b", ",cde,%w+f,"}
+        ut\assertEquals g, {"a", "b", "", "cde", "%w+f", ""}
+        ut\assertEquals h, {strs.splitString}
+        ut\assertEquals {an, bn, cn, dn, en, fn, gn, hn}, {6, 2, 4, 2, 6, 3, 6, 1}
+
+      _order: {"split"}
+    }
   }


### PR DESCRIPTION
This adds an argument to tell the split function how many parts to split the string into at most. E.g. if you tell it to split `"a,b,c,d"` at `","` and return at most 3 parts, you'll get `{"a", "b", "c,d"}` back. Example use case: Split an .ass dialogue line at `,` while ignoring commas in the text field.

Also makes the function more consistent in that it returns the number of parts even if it only returns one element.